### PR TITLE
fix(security): remove reflected XSS (CWE-79) in test url view

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -11,7 +11,10 @@ from django.views.i18n import JavaScriptCatalog
 
 
 def tagged(request, slug):
-    return HttpResponse(slug)
+    # Reversal-only fixture: ``MyTag.get_absolute_url`` reverses the ``tagged``
+    # route name; no test inspects the body. Do NOT echo the user-provided slug
+    # back in the response — that is reflected XSS (CWE-79) and CodeQL flags it.
+    return HttpResponse("ok")
 
 
 urlpatterns = [


### PR DESCRIPTION
## Summary

Clears `django-hashtag`'s only open code-scanning alert: CodeQL `py/reflective-xss` (CWE-79 / CWE-116, **high**) at `tests/urls.py:14`.

The `tagged` test view is a **reversal-only fixture** — it exists so `MyTag.get_absolute_url` can reverse the `tagged` route name. It echoed the user-provided `slug` straight back into the `HttpResponse` body, which CodeQL (correctly) flags as reflected server-side XSS. No test inspects the response body, so the view now returns a constant.

## Why this matters (fleet hardening)

Part of the security non-regression effort: a CWE was attributed to our package in the Security tab. This removes the finding at the source. CI-level non-regression gates (CodeQL gating + SCA) are tracked separately in `DLRSP/workflows`.

## Test plan

- [ ] `ci / test` green (URL-reversal tests unaffected — body not asserted)
- [ ] `ci / Analyze` (CodeQL) reports 0 open alerts after merge
